### PR TITLE
feat: 设计如何以组件的形式修改配置，以title为例实现

### DIFF
--- a/.umirc.ts
+++ b/.umirc.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'dumi';
 
 export default defineConfig({
-  title: 'Library Name',
+  title: 'G2Charts',
   // more config: https://d.umijs.org/config
 });

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,2 +1,50 @@
 
-## Hello dumi!
+# 简介
+
+基于 React 封装的 G2Plot 组件，期望在项目中像使用组件一样使用 [G2Plot](https://g2plot.antv.vision/zh)。
+
+## 特性
+
+- 组件化设计，清晰明了
+- 支持 React Hooks
+- 使用 Typescript 编写
+- 全面支持 G2Plot 的所有组件和特性
+
+## 安装
+
+```bash
+yarn add g2charts
+```
+
+## 使用
+
+```tsx
+import React from 'react';
+import { G2Chart } from 'g2charts';
+const type = 'Line';
+const data = [
+  { year: '1991', value: 3 },
+  { year: '1992', value: 4 },
+  { year: '1993', value: 3.5 },
+  { year: '1994', value: 5 },
+  { year: '1995', value: 4.9 },
+  { year: '1996', value: 6 },
+  { year: '1997', value: 7 },
+  { year: '1998', value: 9 },
+  { year: '1999', value: 13 },
+];
+const configs = {
+  title: {
+    visible: true,
+    text: '折线图',
+  },
+  description: {
+    visible: true,
+    text: '用平滑的曲线代替折线。',
+  },
+  data,
+  xField: 'year',
+  yField: 'value',
+}
+export default () => <G2Chart type={type} config={configs}/>;
+```

--- a/src/Chart/index.tsx
+++ b/src/Chart/index.tsx
@@ -1,32 +1,30 @@
-import React, { FC, useRef, useEffect, Fragment } from 'react';
+import React, { FC, useRef, useEffect, Fragment, useState } from 'react';
 import useChart from './useChart';
 
 export interface G2ChartProps {
   className?: React.HTMLAttributes<HTMLDivElement>['className'];
   children?: React.ReactNode;
-  configs: any;
+  config: any;
   style?: React.HTMLAttributes<HTMLDivElement>['style'];
   type: string;
 }
 
-const Chart: FC<G2ChartProps> = ({ children, configs, type, className, style }) => {
+const Chart: FC<G2ChartProps> = ({ children, config, type, className, style }) => {
   const elmRef = useRef<HTMLDivElement>(null);
-  const { chart, setChart, container, setContainer, } = useChart({ container: elmRef.current as (string | HTMLDivElement), configs, type });
+  const [chartConfig, setChartConfig] = useState(config);
+  const { chart, setChart, container, setContainer } = useChart({ container: elmRef.current as (string | HTMLDivElement), config: chartConfig, type });
   const childs = React.Children.toArray(children);
-  useEffect(() => {
-    if (chart)
-      chart.render();
-  }, [chart])
+
   useEffect(() => setContainer(elmRef.current as string | HTMLDivElement | undefined), [elmRef.current]);
 
   return (
     <Fragment>
       <div ref={elmRef} className={className} style={{ fontSize: 1, height: '100%', ...style }} />
-      {chart && typeof children === 'function' && children({ chart, container })}
+      {chart && typeof children === 'function' && children({ chart })}
       {chart && childs.map((child) => {
         if (!React.isValidElement(child)) return;
         return React.cloneElement(child, {
-          ...child.props, chart, container,
+          ...child.props, chart, setChartConfig
         });
       })}
     </Fragment>

--- a/src/Chart/useChart.tsx
+++ b/src/Chart/useChart.tsx
@@ -1,35 +1,47 @@
 import { useEffect, useState, useMemo } from 'react';
 import * as G2Plot from '@antv/g2plot';
+import isEqual from 'lodash/isEqual';
+import { G2ChartProps } from './'
+import { ChartProp } from '../types'
 
-export interface UseChart {
+export interface UseChart extends G2ChartProps {
   /**
-   * 指定的容器
-   */
+  * 指定的容器
+  */
   container?: string | HTMLDivElement;
-  /**
-   * 图表的配置
-   */
-  configs: any;
-  /**
-   * 图表的类型
-   */
-  type: string;
 }
 
 export default (props: UseChart) => {
-  const { type, configs } = props;
-  const [chart, setChart] = useState();
+  const { type, config } = props;
+  const [chart, setChart] = useState<ChartProp>();
+  const [preConfig, setPreConfig] = useState<ChartProp>(config);
   const [container, setContainer] = useState(props.container);
+
   const getType = (a: string): string => {
     return a as string;
   }
   useMemo(() => {
     if (container && !chart) {
       // @ts-ignore
-      const instance = new G2Plot[getType(type)](container, configs);
+      const instance = new G2Plot[getType(type)](container, config);
       setChart(instance);
     }
-  }, [container, chart]);
+    if (chart && !isEqual(config, preConfig)) {
+      chart.updateConfig(config);
+    }
+    setPreConfig(config);
+    return () => {
+      if (chart && !chart.destroyed) {
+        chart.destroy();
+      }
+    }
+  }, [container, chart, config, type]);
+
+  useEffect(() => {
+    if (chart) {
+      chart.render();
+    }
+  }, [chart, config])
 
   return {
     chart, setChart,

--- a/src/Title/index.md
+++ b/src/Title/index.md
@@ -1,11 +1,11 @@
 
-## Chart
+## Title
 
 Demo:
 
 ```tsx
 import React from 'react';
-import { G2Chart } from 'g2charts';
+import {G2Chart,G2Title } from 'g2charts';
 const type = 'Line';
 const data = [
   { year: '1991', value: 3 },
@@ -31,14 +31,14 @@ const configs = {
   xField: 'year',
   yField: 'value',
 }
-export default () => <G2Chart type={type} config={configs}/>;
+export default () => <G2Chart type={type} config={configs}><G2Title text='折线图1'/></G2Chart>;
 ```
 
 Hooks
 
 ```tsx
 import React, { FC, useRef, useEffect, Fragment, useState } from 'react';
-import { useChart } from 'g2charts';
+import { useChart,useTitle } from 'g2charts';
 const type = 'Line';
 const data = [
   { year: '1991', value: 3 },
@@ -69,23 +69,15 @@ export default () =>  {
   const elmRef = useRef<HTMLDivElement>(null);
   const [chartConfig, setChartConfig] = useState(configs);
   const { chart, setChart, container, setContainer } = useChart({ container: elmRef.current as (string | HTMLDivElement), config: chartConfig, type });
-
+  const titleConfig = {
+    // visible: false,
+    // text: '折线图123',
+  }
+  const {} = useTitle({chart,setChartConfig,...titleConfig})
   useEffect(() => setContainer(elmRef.current as string | HTMLDivElement | undefined), [elmRef.current]);
 
   return (
     <Fragment>
-      <button onClick={()=>{
-        chart.updateConfig({title:{
-          text:'修改后的标题'
-        }})
-        chart.render();
-      }}>修改配置</button>
-      <button onClick={()=>{
-        console.log(chart.getData())
-      }}>获取图表数据</button>
-      <button onClick={()=>{
-        console.log(chart.getPlotTheme())
-      }}>获取图表主题</button>
       <div ref={elmRef} style={{ fontSize: 1, height: '100%' }} />
     </Fragment>
   );

--- a/src/Title/index.tsx
+++ b/src/Title/index.tsx
@@ -1,0 +1,16 @@
+import React, { FC } from 'react';
+import { Label } from '@antv/g2plot';
+import { ChartProp } from '../types'
+import useTitle from './useTitle';
+
+export interface TitleProps extends Label {
+  chart?: ChartProp;
+  setChartConfig?: (d: any) => void;
+}
+
+const Title: FC<TitleProps> = (props) => {
+  useTitle(props);
+  return null;
+}
+
+export default Title

--- a/src/Title/useTitle.tsx
+++ b/src/Title/useTitle.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { TitleProps } from './';
+
+export interface UseLabel extends TitleProps { }
+
+export default (props = {} as UseLabel) => {
+  const [title, setTitle] = useState<UseLabel>();
+  const { chart, setChartConfig, ...other } = props;
+
+  useEffect(() => {
+    if (!chart) return;
+    if (!title) {
+      setChartConfig!({ title: { visible: true, ...other } } as any);
+    };
+    setTitle(other);
+  }, [chart]);
+
+  return {
+    title, setTitle
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,5 @@
-export { default as Chart } from './Chart';
+export { default as G2Chart } from './Chart';
+export { default as useChart } from './Chart/useChart';
+
+export { default as G2Title } from './Title';
+export { default as useTitle } from './Title/useTitle';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,4 @@
+import BasePlot from '@antv/g2plot/esm/base/plot';
+
+
+export interface ChartProp extends BasePlot { }


### PR DESCRIPTION
Close: https://github.com/alitajs/g2charts/issues/3

使用 Chart 包裹的自组件，会传递两个参数 chart 、 setChartConfig，通过组件 G2Title 的属性来配置 title 。
```
const props = {
    text?:string;
    visible?: boolean;
    type?: string;
    formatter?: (text: string | number | undefined | null, item: any, idx: number, ...extras: any[]) => string;
    /** 精度配置，可通过自定义精度来固定数值类型 label 格式 */
    precision?: number;
    /** 添加后缀 */
    suffix?: string;
    style?: TextStyle;
    offset?: number;
    offsetX?: number;
    offsetY?: number;
    position?: string;
    adjustColor?: boolean;
    adjustPosition?: boolean;
    autoRotate?: boolean;
}
<G2Title {...props} />
```
默认有G2Title的时候，config 中的 visible 默认为 true ，可以通过显示的设置 visible 为 false，来隐藏渲染标题。

支持 React hooks 的用法

```tsx
useTitle({chart,setChartConfig,...props})
```
