### PR TITLE
feat: components config

### DIFF
--- a/src/Description/index.md
+++ b/src/Description/index.md
@@ -1,11 +1,11 @@
 
-## Title
+## Description
 
 Demo:
 
 ```tsx
 import React, { useRef, Fragment } from 'react';
-import { G2Chart, G2Title } from 'g2charts';
+import { G2Chart, G2Description } from 'g2charts';
 const type = 'Line';
 const data = [
   { year: '1991', value: 3 },
@@ -37,12 +37,12 @@ export default () => {
 
   return (<Fragment>
     <button onClick={() => {
-      elmRef.current.setTitle({
-        text: '修改后的标题'
+      elmRef.current.setDescription({
+        text: '修改后的图表描述'
       })
     }}>修改配置</button>
     <G2Chart type={type} config={configs}>
-      <G2Title text='折线图1' ref={elmRef} />
+      <G2Description text='图表描述' ref={elmRef} />
     </G2Chart>
   </Fragment>)
 };
@@ -52,7 +52,7 @@ Hooks
 
 ```tsx
 import React, { FC, useRef, useEffect, Fragment, useState } from 'react';
-import { useChart,useTitle } from 'g2charts';
+import { useChart,useDescription } from 'g2charts';
 const type = 'Line';
 const data = [
   { year: '1991', value: 3 },
@@ -83,16 +83,15 @@ export default () =>  {
   const elmRef = useRef<HTMLDivElement>(null);
   const [chartConfig, setChartConfig] = useState(configs);
   const { chart, setChart, container, setContainer } = useChart({ container: elmRef.current as (string | HTMLDivElement), config: chartConfig, type });
-  const titleConfig = {
-    // visible: false,
-    text: '折线图123',
+  const descriptionConfig = {
+    text: '图表描述',
   }
-  const {title,setTitle} = useTitle({chart,setChartConfig,...titleConfig})
+  const {description,setDescription} = useDescription({chart,setChartConfig,...descriptionConfig})
   useEffect(() => setContainer(elmRef.current as string | HTMLDivElement | undefined), [elmRef.current]);
 
   return (
     <Fragment>
-      <button onClick={()=>{setTitle({text:'修改后的标题'})}}>修改配置</button>
+      <button onClick={()=>{setDescription({text:'修改后的图表描述'})}}>修改配置</button>
       <div ref={elmRef} style={{ fontSize: 1, height: '100%' }} />
     </Fragment>
   );

--- a/src/Description/index.tsx
+++ b/src/Description/index.tsx
@@ -1,0 +1,17 @@
+import React, { FC, forwardRef, useImperativeHandle } from 'react';
+import { IDescription } from '@antv/g2plot';
+import { ChartProp } from '../types'
+import useDescription from './useDescription';
+
+export interface DescriptionProps extends IDescription {
+  chart?: ChartProp;
+  setChartConfig?: (d: any) => void;
+}
+
+const Description: FC<DescriptionProps> = forwardRef((props, ref) => {
+  const { description, setDescription } = useDescription(props);
+  useImperativeHandle(ref, () => ({ description, setDescription }), [description]);
+  return null;
+})
+
+export default Description;

--- a/src/Description/useDescription.tsx
+++ b/src/Description/useDescription.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import isEqual from 'lodash/isEqual';
+import { DescriptionProps } from './';
+
+export interface UseDescription extends DescriptionProps { }
+
+export default (props = {} as UseDescription) => {
+  const { chart, setChartConfig, ...other } = props;
+  const [description, setDescription] = useState<UseDescription>(other);
+  const [preDescription, setPreDescription] = useState<UseDescription>();
+
+  useEffect(() => {
+    if (!chart) return;
+    if (!isEqual(description, preDescription)) {
+      setChartConfig!({ description: { visible: true, ...description } } as any);
+      setPreDescription(description);
+    };
+  }, [chart, description]);
+
+  return {
+    description, setDescription
+  };
+}

--- a/src/GuideLine/index.md
+++ b/src/GuideLine/index.md
@@ -1,11 +1,11 @@
 
-## Title
+## GuideLine
 
 Demo:
 
 ```tsx
 import React, { useRef, Fragment } from 'react';
-import { G2Chart, G2Title } from 'g2charts';
+import { G2Chart, G2GuideLine } from 'g2charts';
 const type = 'Line';
 const data = [
   { year: '1991', value: 3 },
@@ -27,6 +27,15 @@ const configs = {
     visible: true,
     text: '用平滑的曲线代替折线。',
   },
+  guideLine: [
+    {
+      type: 'mean',
+      lineStyle: {},
+      text: {
+        content:'1232'
+      },
+    },
+  ],
   data,
   xField: 'year',
   yField: 'value',
@@ -37,22 +46,22 @@ export default () => {
 
   return (<Fragment>
     <button onClick={() => {
-      elmRef.current.setTitle({
+      elmRef.current.setGuideLine({
         text: '修改后的标题'
       })
     }}>修改配置</button>
     <G2Chart type={type} config={configs}>
-      <G2Title text='折线图1' ref={elmRef} />
+      <G2GuideLine  ref={elmRef} />
     </G2Chart>
   </Fragment>)
 };
 ```
 
 Hooks
-
+<!--
 ```tsx
 import React, { FC, useRef, useEffect, Fragment, useState } from 'react';
-import { useChart,useTitle } from 'g2charts';
+import { useChart,useGuideLine } from 'g2charts';
 const type = 'Line';
 const data = [
   { year: '1991', value: 3 },
@@ -83,18 +92,18 @@ export default () =>  {
   const elmRef = useRef<HTMLDivElement>(null);
   const [chartConfig, setChartConfig] = useState(configs);
   const { chart, setChart, container, setContainer } = useChart({ container: elmRef.current as (string | HTMLDivElement), config: chartConfig, type });
-  const titleConfig = {
+  const guideLineConfig = {
     // visible: false,
     text: '折线图123',
   }
-  const {title,setTitle} = useTitle({chart,setChartConfig,...titleConfig})
+  const {guideLine,setGuideLine} = useGuideLine({chart,setChartConfig,...guideLineConfig})
   useEffect(() => setContainer(elmRef.current as string | HTMLDivElement | undefined), [elmRef.current]);
 
   return (
     <Fragment>
-      <button onClick={()=>{setTitle({text:'修改后的标题'})}}>修改配置</button>
+      <button onClick={()=>{setGuideLine({text:'修改后的标题'})}}>修改配置</button>
       <div ref={elmRef} style={{ fontSize: 1, height: '100%' }} />
     </Fragment>
   );
 };
-```
+``` -->

--- a/src/GuideLine/index.tsx
+++ b/src/GuideLine/index.tsx
@@ -1,0 +1,17 @@
+import React, { FC, forwardRef, useImperativeHandle } from 'react';
+import { GuideLineConfig } from '@antv/g2plot';
+import { ChartProp } from '../types'
+import useGuideLine from './useGuideLine';
+
+export interface GuideLineProps extends GuideLineConfig {
+  chart?: ChartProp;
+  setChartConfig?: (d: any) => void;
+}
+
+const GuideLine: FC<GuideLineProps> = forwardRef((props, ref) => {
+  const { guideLine, setGuideLine } = useGuideLine(props);
+  useImperativeHandle(ref, () => ({ guideLine, setGuideLine }), [guideLine]);
+  return null;
+})
+
+export default GuideLine

--- a/src/GuideLine/useGuideLine.tsx
+++ b/src/GuideLine/useGuideLine.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import isEqual from 'lodash/isEqual';
+import { GuideLineProps } from './';
+
+export interface UseGuideLine extends GuideLineProps { }
+
+export default (props = {} as UseGuideLine) => {
+  const { chart, setChartConfig, ...other } = props;
+  const [guideLine, setGuideLine] = useState<UseGuideLine>(other);
+  const [preGuideLine, setPreGuideLine] = useState<UseGuideLine>();
+
+  useEffect(() => {
+    if (!chart) return;
+    if (!isEqual(guideLine, preGuideLine)) {
+      const config = chart.getPlotTheme();
+      console.log(config);
+      // setChartConfig!({ guideLine: { visible: true, ...guideLine } } as any);
+      setPreGuideLine(guideLine);
+    };
+  }, [chart, guideLine]);
+
+  return {
+    guideLine, setGuideLine
+  };
+}

--- a/src/Label/index.md
+++ b/src/Label/index.md
@@ -1,0 +1,190 @@
+
+## Label
+
+Demo:
+
+```tsx
+import React, { useRef, Fragment } from 'react';
+import { G2Chart, G2Label } from 'g2charts';
+const type = 'Line';
+const data = [
+  {
+    date: '2018/8/1',
+    type: 'download',
+    value: 4623,
+  },
+  {
+    date: '2018/8/1',
+    type: 'register',
+    value: 2208,
+  },
+  {
+    date: '2018/8/1',
+    type: 'bill',
+    value: 182,
+  },
+  {
+    date: '2018/8/2',
+    type: 'download',
+    value: 6145,
+  },
+  {
+    date: '2018/8/2',
+    type: 'register',
+    value: 2016,
+  },
+  {
+    date: '2018/8/2',
+    type: 'bill',
+    value: 257,
+  },
+  {
+    date: '2018/8/3',
+    type: 'download',
+    value: 508,
+  },
+  {
+    date: '2018/8/3',
+    type: 'register',
+    value: 2916,
+  },
+  {
+    date: '2018/8/3',
+    type: 'bill',
+    value: 289,
+  },
+  {
+    date: '2018/8/4',
+    type: 'download',
+    value: 6268,
+  },
+];
+const configs = {
+  title: {
+    visible: true,
+    text: '折线图',
+  },
+  description: {
+    visible: true,
+    text: '用平滑的曲线代替折线。',
+  },
+  data,
+  legend:{
+    position:'top-center'
+  },
+  xField: 'date',
+  yField: 'value',
+  seriesField: 'type',
+}
+export default () => {
+  const elmRef = useRef<HTMLDivElement>(null);
+
+  return (<Fragment>
+    <button onClick={() => {
+      elmRef.current.setLabel({
+        type: 'point'
+      })
+    }}>修改配置</button>
+    <G2Chart type={type} config={configs}>
+      <G2Label type='line' ref={elmRef} />
+    </G2Chart>
+  </Fragment>)
+};
+```
+
+Hooks
+
+```tsx
+import React, { FC, useRef, useEffect, Fragment, useState } from 'react';
+import { useChart,useLabel } from 'g2charts';
+const type = 'Line';
+const data = [
+  {
+    date: '2018/8/1',
+    type: 'download',
+    value: 4623,
+  },
+  {
+    date: '2018/8/1',
+    type: 'register',
+    value: 2208,
+  },
+  {
+    date: '2018/8/1',
+    type: 'bill',
+    value: 182,
+  },
+  {
+    date: '2018/8/2',
+    type: 'download',
+    value: 6145,
+  },
+  {
+    date: '2018/8/2',
+    type: 'register',
+    value: 2016,
+  },
+  {
+    date: '2018/8/2',
+    type: 'bill',
+    value: 257,
+  },
+  {
+    date: '2018/8/3',
+    type: 'download',
+    value: 508,
+  },
+  {
+    date: '2018/8/3',
+    type: 'register',
+    value: 2916,
+  },
+  {
+    date: '2018/8/3',
+    type: 'bill',
+    value: 289,
+  },
+  {
+    date: '2018/8/4',
+    type: 'download',
+    value: 6268,
+  },
+];
+const configs = {
+  title: {
+    visible: true,
+    text: '折线图',
+  },
+  description: {
+    visible: true,
+    text: '用平滑的曲线代替折线。',
+  },
+  data,
+  legend:{
+    position:'top-center'
+  },
+  xField: 'date',
+  yField: 'value',
+  seriesField: 'type',
+}
+
+export default () =>  {
+  const elmRef = useRef<HTMLDivElement>(null);
+  const [chartConfig, setChartConfig] = useState(configs);
+  const { chart, setChart, container, setContainer } = useChart({ container: elmRef.current as (string | HTMLDivElement), config: chartConfig, type });
+  const labelConfig = {
+    type:'line'
+  }
+  const {label,setLabel} = useLabel({chart,setChartConfig,...labelConfig})
+  useEffect(() => setContainer(elmRef.current as string | HTMLDivElement | undefined), [elmRef.current]);
+
+  return (
+    <Fragment>
+      <button onClick={()=>{setLabel({
+        type: 'point'
+      })}}>修改配置</button>
+      <div ref={elmRef} style={{ fontSize: 1, height: '100%' }} />
+    </Fragment>
+  );
+};
+```

--- a/src/Label/index.tsx
+++ b/src/Label/index.tsx
@@ -1,0 +1,17 @@
+import React, { FC, forwardRef, useImperativeHandle } from 'react';
+import { Label as LabelConfig } from '@antv/g2plot';
+import { ChartProp } from '../types'
+import useLabel from './useLabel';
+
+export interface LabelProps extends LabelConfig {
+  chart?: ChartProp;
+  setChartConfig?: (d: any) => void;
+}
+
+const Label: FC<LabelProps> = forwardRef((props, ref) => {
+  const { label, setLabel } = useLabel(props);
+  useImperativeHandle(ref, () => ({ label, setLabel }), [label]);
+  return null;
+})
+
+export default Label

--- a/src/Label/useLabel.tsx
+++ b/src/Label/useLabel.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import isEqual from 'lodash/isEqual';
+import { LabelProps } from './';
+
+export interface UseLabel extends LabelProps { }
+
+export default (props = {} as UseLabel) => {
+  const { chart, setChartConfig, ...other } = props;
+  const [label, setLabel] = useState<UseLabel>(other);
+  const [preLabel, setPreLabel] = useState<UseLabel>();
+
+  useEffect(() => {
+    if (!chart) return;
+    if (!isEqual(label, preLabel)) {
+      setChartConfig!({ label: { visible: true, ...label } } as any);
+      setPreLabel(label);
+    };
+  }, [chart, label]);
+
+  return {
+    label, setLabel
+  };
+}

--- a/src/Legend/index.md
+++ b/src/Legend/index.md
@@ -1,0 +1,191 @@
+
+## Legend
+
+Demo:
+
+```tsx
+import React, { useRef, Fragment } from 'react';
+import { G2Chart, G2Legend } from 'g2charts';
+const type = 'Line';
+const data = [
+  {
+    date: '2018/8/1',
+    type: 'download',
+    value: 4623,
+  },
+  {
+    date: '2018/8/1',
+    type: 'register',
+    value: 2208,
+  },
+  {
+    date: '2018/8/1',
+    type: 'bill',
+    value: 182,
+  },
+  {
+    date: '2018/8/2',
+    type: 'download',
+    value: 6145,
+  },
+  {
+    date: '2018/8/2',
+    type: 'register',
+    value: 2016,
+  },
+  {
+    date: '2018/8/2',
+    type: 'bill',
+    value: 257,
+  },
+  {
+    date: '2018/8/3',
+    type: 'download',
+    value: 508,
+  },
+  {
+    date: '2018/8/3',
+    type: 'register',
+    value: 2916,
+  },
+  {
+    date: '2018/8/3',
+    type: 'bill',
+    value: 289,
+  },
+  {
+    date: '2018/8/4',
+    type: 'download',
+    value: 6268,
+  },
+];
+const configs = {
+  title: {
+    visible: true,
+    text: '折线图',
+  },
+  description: {
+    visible: true,
+    text: '用平滑的曲线代替折线。',
+  },
+  data,
+  legend:{
+    position:'top-center'
+  },
+  xField: 'date',
+  yField: 'value',
+  seriesField: 'type',
+}
+
+export default () => {
+  const elmRef = useRef<HTMLDivElement>(null);
+
+  return (<Fragment>
+    <button onClick={() => {
+      elmRef.current.setLegend({
+        position: 'top-center',
+      })
+    }}>修改配置</button>
+    <G2Chart type={type} config={configs}>
+      <G2Legend position='botto-left' ref={elmRef} />
+    </G2Chart>
+  </Fragment>)
+};
+```
+
+Hooks
+
+```tsx
+import React, { FC, useRef, useEffect, Fragment, useState } from 'react';
+import { useChart,useLegend } from 'g2charts';
+const type = 'Line';
+const data = [
+  {
+    date: '2018/8/1',
+    type: 'download',
+    value: 4623,
+  },
+  {
+    date: '2018/8/1',
+    type: 'register',
+    value: 2208,
+  },
+  {
+    date: '2018/8/1',
+    type: 'bill',
+    value: 182,
+  },
+  {
+    date: '2018/8/2',
+    type: 'download',
+    value: 6145,
+  },
+  {
+    date: '2018/8/2',
+    type: 'register',
+    value: 2016,
+  },
+  {
+    date: '2018/8/2',
+    type: 'bill',
+    value: 257,
+  },
+  {
+    date: '2018/8/3',
+    type: 'download',
+    value: 508,
+  },
+  {
+    date: '2018/8/3',
+    type: 'register',
+    value: 2916,
+  },
+  {
+    date: '2018/8/3',
+    type: 'bill',
+    value: 289,
+  },
+  {
+    date: '2018/8/4',
+    type: 'download',
+    value: 6268,
+  },
+];
+const configs = {
+  title: {
+    visible: true,
+    text: '折线图',
+  },
+  description: {
+    visible: true,
+    text: '用平滑的曲线代替折线。',
+  },
+  data,
+  legend:{
+    position:'top-center'
+  },
+  xField: 'date',
+  yField: 'value',
+  seriesField: 'type',
+}
+
+export default () =>  {
+  const elmRef = useRef<HTMLDivElement>(null);
+  const [chartConfig, setChartConfig] = useState(configs);
+  const { chart, setChart, container, setContainer } = useChart({ container: elmRef.current as (string | HTMLDivElement), config: chartConfig, type });
+  const legendConfig = {
+     position:'botto-left'
+  }
+  const {legend,setLegend} = useLegend({chart,setChartConfig,...legendConfig})
+  useEffect(() => setContainer(elmRef.current as string | HTMLDivElement | undefined), [elmRef.current]);
+
+  return (
+    <Fragment>
+      <button onClick={()=>{setLegend({
+        position: 'top-center',
+      })}}>修改配置</button>
+      <div ref={elmRef} style={{ fontSize: 1, height: '100%' }} />
+    </Fragment>
+  );
+};
+```

--- a/src/Legend/index.tsx
+++ b/src/Legend/index.tsx
@@ -1,0 +1,17 @@
+import React, { FC, forwardRef, useImperativeHandle } from 'react';
+import { Legend as LegendConfig} from '@antv/g2plot';
+import { ChartProp } from '../types'
+import useLegend from './useLegend';
+
+export interface LegendProps extends LegendConfig {
+  chart?: ChartProp;
+  setChartConfig?: (d: any) => void;
+}
+
+const Legend: FC<LegendProps> = forwardRef((props, ref) => {
+  const { legend, setLegend } = useLegend(props);
+  useImperativeHandle(ref, () => ({ legend, setLegend }), [legend]);
+  return null;
+})
+
+export default Legend

--- a/src/Legend/useLegend.tsx
+++ b/src/Legend/useLegend.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import isEqual from 'lodash/isEqual';
+import { LegendProps } from './';
+
+export interface UseLegend extends LegendProps { }
+
+export default (props = {} as UseLegend) => {
+  const { chart, setChartConfig, ...other } = props;
+  const [legend, setLegend] = useState<UseLegend>(other);
+  const [preLegend, setPreLegend] = useState<UseLegend>();
+
+  useEffect(() => {
+    if (!chart) return;
+    if (!isEqual(legend, preLegend)) {
+      setChartConfig!({ legend: { visible: true, ...legend } } as any);
+      setPreLegend(legend);
+    };
+  }, [chart, legend]);
+
+  return {
+    legend, setLegend
+  };
+}

--- a/src/Title/index.tsx
+++ b/src/Title/index.tsx
@@ -1,9 +1,9 @@
 import React, { FC, forwardRef, useImperativeHandle } from 'react';
-import { Label } from '@antv/g2plot';
+import { ITitle } from '@antv/g2plot';
 import { ChartProp } from '../types'
 import useTitle from './useTitle';
 
-export interface TitleProps extends Label {
+export interface TitleProps extends ITitle {
   chart?: ChartProp;
   setChartConfig?: (d: any) => void;
 }

--- a/src/Title/useTitle.tsx
+++ b/src/Title/useTitle.tsx
@@ -2,12 +2,12 @@ import { useEffect, useState } from 'react';
 import isEqual from 'lodash/isEqual';
 import { TitleProps } from './';
 
-export interface UseLabel extends TitleProps { }
+export interface UseTitle extends TitleProps { }
 
-export default (props = {} as UseLabel) => {
+export default (props = {} as UseTitle) => {
   const { chart, setChartConfig, ...other } = props;
-  const [title, setTitle] = useState<UseLabel>(other);
-  const [preTitle, setPreTitle] = useState<UseLabel>();
+  const [title, setTitle] = useState<UseTitle>(other);
+  const [preTitle, setPreTitle] = useState<UseTitle>();
 
   useEffect(() => {
     if (!chart) return;

--- a/src/Tooltip/index.md
+++ b/src/Tooltip/index.md
@@ -1,11 +1,11 @@
 
-## Title
+## Tooltip
 
 Demo:
 
 ```tsx
 import React, { useRef, Fragment } from 'react';
-import { G2Chart, G2Title } from 'g2charts';
+import { G2Chart, G2Tooltip } from 'g2charts';
 const type = 'Line';
 const data = [
   { year: '1991', value: 3 },
@@ -37,12 +37,12 @@ export default () => {
 
   return (<Fragment>
     <button onClick={() => {
-      elmRef.current.setTitle({
+      elmRef.current.setTooltip({
         text: '修改后的标题'
       })
     }}>修改配置</button>
     <G2Chart type={type} config={configs}>
-      <G2Title text='折线图1' ref={elmRef} />
+      <G2Tooltip text='折线图1' ref={elmRef} />
     </G2Chart>
   </Fragment>)
 };
@@ -52,7 +52,7 @@ Hooks
 
 ```tsx
 import React, { FC, useRef, useEffect, Fragment, useState } from 'react';
-import { useChart,useTitle } from 'g2charts';
+import { useChart,useTooltip } from 'g2charts';
 const type = 'Line';
 const data = [
   { year: '1991', value: 3 },
@@ -83,16 +83,16 @@ export default () =>  {
   const elmRef = useRef<HTMLDivElement>(null);
   const [chartConfig, setChartConfig] = useState(configs);
   const { chart, setChart, container, setContainer } = useChart({ container: elmRef.current as (string | HTMLDivElement), config: chartConfig, type });
-  const titleConfig = {
+  const tooltipConfig = {
     // visible: false,
     text: '折线图123',
   }
-  const {title,setTitle} = useTitle({chart,setChartConfig,...titleConfig})
+  const {tooltip,setTooltip} = useTooltip({chart,setChartConfig,...tooltipConfig})
   useEffect(() => setContainer(elmRef.current as string | HTMLDivElement | undefined), [elmRef.current]);
 
   return (
     <Fragment>
-      <button onClick={()=>{setTitle({text:'修改后的标题'})}}>修改配置</button>
+      <button onClick={()=>{setTooltip({text:'修改后的标题'})}}>修改配置</button>
       <div ref={elmRef} style={{ fontSize: 1, height: '100%' }} />
     </Fragment>
   );

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -1,0 +1,17 @@
+import React, { FC, forwardRef, useImperativeHandle } from 'react';
+import { Tooltip as TooltipConfig } from '@antv/g2plot';
+import { ChartProp } from '../types'
+import useTooltip from './useTooltip';
+
+export interface TooltipProps extends TooltipConfig {
+  chart?: ChartProp;
+  setChartConfig?: (d: any) => void;
+}
+
+const Tooltip: FC<TooltipProps> = forwardRef((props, ref) => {
+  const { tooltip, setTooltip } = useTooltip(props);
+  useImperativeHandle(ref, () => ({ tooltip, setTooltip }), [tooltip]);
+  return null;
+})
+
+export default Tooltip

--- a/src/Tooltip/useTooltip.tsx
+++ b/src/Tooltip/useTooltip.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import isEqual from 'lodash/isEqual';
+import { TooltipProps } from './';
+
+export interface UseTooltip extends TooltipProps { }
+
+export default (props = {} as UseTooltip) => {
+  const { chart, setChartConfig, ...other } = props;
+  const [tooltip, setTooltip] = useState<UseTooltip>(other);
+  const [preTooltip, setPreTooltip] = useState<UseTooltip>();
+
+  useEffect(() => {
+    if (!chart) return;
+    if (!isEqual(tooltip, preTooltip)) {
+      setChartConfig!({ tooltip: { visible: true, ...tooltip } } as any);
+      setPreTooltip(tooltip);
+    };
+  }, [chart, tooltip]);
+
+  return {
+    tooltip, setTooltip
+  };
+}

--- a/src/XAxis/index.md
+++ b/src/XAxis/index.md
@@ -1,11 +1,11 @@
 
-## Title
+## XAxis
 
 Demo:
 
 ```tsx
 import React, { useRef, Fragment } from 'react';
-import { G2Chart, G2Title } from 'g2charts';
+import { G2Chart, G2XAxis } from 'g2charts';
 const type = 'Line';
 const data = [
   { year: '1991', value: 3 },
@@ -29,6 +29,9 @@ const configs = {
   },
   data,
   xField: 'year',
+  xAxis:{
+    type:'time'
+  },
   yField: 'value',
 }
 
@@ -37,12 +40,12 @@ export default () => {
 
   return (<Fragment>
     <button onClick={() => {
-      elmRef.current.setTitle({
-        text: '修改后的标题'
+      elmRef.current.setXAxis({
+        type:'time'
       })
     }}>修改配置</button>
     <G2Chart type={type} config={configs}>
-      <G2Title text='折线图1' ref={elmRef} />
+      <G2XAxis type='linear' ref={elmRef} />
     </G2Chart>
   </Fragment>)
 };
@@ -52,7 +55,7 @@ Hooks
 
 ```tsx
 import React, { FC, useRef, useEffect, Fragment, useState } from 'react';
-import { useChart,useTitle } from 'g2charts';
+import { useChart,useXAxis } from 'g2charts';
 const type = 'Line';
 const data = [
   { year: '1991', value: 3 },
@@ -76,6 +79,9 @@ const configs = {
   },
   data,
   xField: 'year',
+  xAxis:{
+    type:'time'
+  },
   yField: 'value',
 }
 
@@ -83,16 +89,16 @@ export default () =>  {
   const elmRef = useRef<HTMLDivElement>(null);
   const [chartConfig, setChartConfig] = useState(configs);
   const { chart, setChart, container, setContainer } = useChart({ container: elmRef.current as (string | HTMLDivElement), config: chartConfig, type });
-  const titleConfig = {
+  const xAxisConfig = {
     // visible: false,
-    text: '折线图123',
+    type:'linear'
   }
-  const {title,setTitle} = useTitle({chart,setChartConfig,...titleConfig})
+  const {xAxis,setXAxis} = useXAxis({chart,setChartConfig,...xAxisConfig})
   useEffect(() => setContainer(elmRef.current as string | HTMLDivElement | undefined), [elmRef.current]);
 
   return (
     <Fragment>
-      <button onClick={()=>{setTitle({text:'修改后的标题'})}}>修改配置</button>
+      <button onClick={()=>{setXAxis({type:'time'})}}>修改配置</button>
       <div ref={elmRef} style={{ fontSize: 1, height: '100%' }} />
     </Fragment>
   );

--- a/src/XAxis/index.tsx
+++ b/src/XAxis/index.tsx
@@ -1,0 +1,17 @@
+import React, { FC, forwardRef, useImperativeHandle } from 'react';
+import { IBaseAxis } from '@antv/g2plot';
+import { ChartProp } from '../types'
+import useXAxis from './useXAxis';
+
+export interface XAxisProps extends IBaseAxis {
+  chart?: ChartProp;
+  setChartConfig?: (d: any) => void;
+}
+
+const XAxis: FC<XAxisProps> = forwardRef((props, ref) => {
+  const { xAxis, setXAxis } = useXAxis(props);
+  useImperativeHandle(ref, () => ({ xAxis, setXAxis }), [xAxis]);
+  return null;
+})
+
+export default XAxis

--- a/src/XAxis/useXAxis.tsx
+++ b/src/XAxis/useXAxis.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import isEqual from 'lodash/isEqual';
+import { XAxisProps } from './';
+
+export interface UseXAxis extends XAxisProps { }
+
+export default (props = {} as UseXAxis) => {
+  const { chart, setChartConfig, ...other } = props;
+  const [xAxis, setXAxis] = useState<UseXAxis>(other);
+  const [preXAxis, setPreXAxis] = useState<UseXAxis>();
+
+  useEffect(() => {
+    if (!chart) return;
+    if (!isEqual(xAxis, preXAxis)) {
+      setChartConfig!({ xAxis: { visible: true, ...xAxis } } as any);
+      setPreXAxis(xAxis);
+    };
+  }, [chart, xAxis]);
+
+  return {
+    xAxis, setXAxis
+  };
+}

--- a/src/YAxis/index.md
+++ b/src/YAxis/index.md
@@ -1,11 +1,11 @@
 
-## Title
+## YAxis
 
 Demo:
 
 ```tsx
 import React, { useRef, Fragment } from 'react';
-import { G2Chart, G2Title } from 'g2charts';
+import { G2Chart, G2YAxis } from 'g2charts';
 const type = 'Line';
 const data = [
   { year: '1991', value: 3 },
@@ -30,6 +30,9 @@ const configs = {
   data,
   xField: 'year',
   yField: 'value',
+  yAxis:{
+    type:'time'
+  },
 }
 
 export default () => {
@@ -37,12 +40,12 @@ export default () => {
 
   return (<Fragment>
     <button onClick={() => {
-      elmRef.current.setTitle({
-        text: '修改后的标题'
+      elmRef.current.setYAxis({
+        type:'time'
       })
     }}>修改配置</button>
     <G2Chart type={type} config={configs}>
-      <G2Title text='折线图1' ref={elmRef} />
+      <G2YAxis type='linear' ref={elmRef} />
     </G2Chart>
   </Fragment>)
 };
@@ -52,7 +55,7 @@ Hooks
 
 ```tsx
 import React, { FC, useRef, useEffect, Fragment, useState } from 'react';
-import { useChart,useTitle } from 'g2charts';
+import { useChart,useYAxis } from 'g2charts';
 const type = 'Line';
 const data = [
   { year: '1991', value: 3 },
@@ -77,22 +80,24 @@ const configs = {
   data,
   xField: 'year',
   yField: 'value',
+  yAxis:{
+    type:'time'
+  },
 }
 
 export default () =>  {
   const elmRef = useRef<HTMLDivElement>(null);
   const [chartConfig, setChartConfig] = useState(configs);
   const { chart, setChart, container, setContainer } = useChart({ container: elmRef.current as (string | HTMLDivElement), config: chartConfig, type });
-  const titleConfig = {
-    // visible: false,
-    text: '折线图123',
+  const yAxisConfig = {
+    type:'linear'
   }
-  const {title,setTitle} = useTitle({chart,setChartConfig,...titleConfig})
+  const {yAxis,setYAxis} = useYAxis({chart,setChartConfig,...yAxisConfig})
   useEffect(() => setContainer(elmRef.current as string | HTMLDivElement | undefined), [elmRef.current]);
 
   return (
     <Fragment>
-      <button onClick={()=>{setTitle({text:'修改后的标题'})}}>修改配置</button>
+      <button onClick={()=>{setYAxis({type:'time'})}}>修改配置</button>
       <div ref={elmRef} style={{ fontSize: 1, height: '100%' }} />
     </Fragment>
   );

--- a/src/YAxis/index.tsx
+++ b/src/YAxis/index.tsx
@@ -1,0 +1,17 @@
+import React, { FC, forwardRef, useImperativeHandle } from 'react';
+import { IBaseAxis } from '@antv/g2plot';
+import { ChartProp } from '../types'
+import useYAxis from './useYAxis';
+
+export interface YAxisProps extends IBaseAxis {
+  chart?: ChartProp;
+  setChartConfig?: (d: any) => void;
+}
+
+const YAxis: FC<YAxisProps> = forwardRef((props, ref) => {
+  const { yAxis, setYAxis } = useYAxis(props);
+  useImperativeHandle(ref, () => ({ yAxis, setYAxis }), [yAxis]);
+  return null;
+})
+
+export default YAxis

--- a/src/YAxis/useYAxis.tsx
+++ b/src/YAxis/useYAxis.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import isEqual from 'lodash/isEqual';
+import { YAxisProps } from './';
+
+export interface UseYAxis extends YAxisProps { }
+
+export default (props = {} as UseYAxis) => {
+  const { chart, setChartConfig, ...other } = props;
+  const [yAxis, setYAxis] = useState<UseYAxis>(other);
+  const [preYAxis, setPreYAxis] = useState<UseYAxis>();
+
+  useEffect(() => {
+    if (!chart) return;
+    if (!isEqual(yAxis, preYAxis)) {
+      setChartConfig!({ yAxis: { visible: true, ...yAxis } } as any);
+      setPreYAxis(yAxis);
+    };
+  }, [chart, yAxis]);
+
+  return {
+    yAxis, setYAxis
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,21 @@
 export { default as G2Chart } from './Chart';
 export { default as useChart } from './Chart/useChart';
 
+
+export { default as G2Description } from './Description';
+export { default as useDescription } from './Description/useDescription';
+// export { default as G2GuideLine } from './GuideLine';
+// export { default as useGuideLine } from './GuideLine/useGuideLine';
+export { default as G2Label } from './Label';
+export { default as useLabel } from './Label/useLabel';
+export { default as G2Legend } from './Legend';
+export { default as useLegend } from './Legend/useLegend';
 export { default as G2Title } from './Title';
 export { default as useTitle } from './Title/useTitle';
-
+export { default as G2Tooltip } from './Tooltip';
+export { default as useTooltip } from './Tooltip/useTooltip';
+export { default as G2XAxis } from './XAxis';
+export { default as useXAxis } from './XAxis/useXAxis';
+export { default as G2YAxis } from './YAxis';
+export { default as useYAxis } from './YAxis/useYAxis';
 export * from './types';


### PR DESCRIPTION
[图表组件](https://g2plot.antv.vision/zh/docs/manual/plots/line/#%E5%9B%BE%E8%A1%A8%E7%BB%84%E4%BB%B6)支持，剩 GuideLine ，因为这个配置是一个数组，期望的用法是，写一个组件就多一个辅助线，而不是 `<GuideLine config={[]}/>`，相关issues：https://github.com/alitajs/g2charts/issues/6
